### PR TITLE
Fixes tiny spelling and capitalizations and a hyphen, adds a mailto link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ _This is a living document and, as such, can and will be adjusted at any time by
 
 ## Code Cafe Online's Code of Conduct:
 
-_this document and the expectations set forth within it apply to any, and all, of Code Cafe Online's members in all spaces, including but not limited to our Discord server and all channels therein, Code Cafe Online's Twitter account, all live streamed content and events including, but not limited to, Zoom calls and Twitch streams, and all private communication between members regardless of where that communication takes place (Discord DMs, Twitter mentions and DMs, Email, Text, etc)._
+_This document and the expectations set forth within it apply to any, and all, of Code Cafe Online's members in all spaces, including but not limited to our Discord server and all channels therein, Code Cafe Online's Twitter account, all live streamed content and events including, but not limited to, Zoom calls and Twitch streams, and all private communication between members regardless of where that communication takes place (Discord DMs, Twitter mentions and DMs, Email, Text, etc)._
 
 ### The Code Cafe Online community expects that all of our community spaces, activities, events, and forums:
 
@@ -23,7 +23,7 @@ _this document and the expectations set forth within it apply to any, and all, o
 
 ### Code Cafe Online's Anti-Harassment Policy and Procedures
 
-_all Code Cafe Online community activities, events, forums, members, admins, moderators, presenters and guests are held to the anti-harassment policy that follows. In addition to governing our own events, content and members, Code Cafe Online will only collaborate and participate with groups that also offer an anti-harassment policy and Code of Conduct to their members and attendees._
+_All Code Cafe Online community activities, events, forums, members, admins, moderators, presenters and guests are held to the anti-harassment policy that follows. In addition to governing our own events, content and members, Code Cafe Online will only collaborate and participate with groups that also offer an anti-harassment policy and Code of Conduct to their members and attendees._
 
 Code Cafe Online is dedicated to providing a harassment-free community for everyone regardless of gender and gender-expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or nationality. We do not tolerate harassment of any kind of admin, moderators, members, and guests.
 
@@ -31,7 +31,7 @@ Harassment includes but is not limited to: offensive and/or derogatory verbal or
 
 If a Code Cafe Online member or guest engages in harassing behavior, admins and moderators may take actions they deem appropriate, including warning the offender (either privately or publicly), and banning the harassing member/guest from further participation in the Code Cafe Online community.
 
-If you are being harassed, notice someone being harassed, or have other concerns relating to activity you see taking place within the community, please contact an admin or moderator immediately. You may contact admins and moderators via Discord DM, Twitter DM to @CodeCafeOnline, in a private chat during a live event, or by emailing TheOriginalPixi@gmail.com. If you choose to contact Emily via email, please use the subject line "CoC Alert for Code Cafe Online".
+If you are being harassed, notice someone being harassed, or have other concerns relating to activity you see taking place within the community, please contact an admin or moderator immediately. You may contact admins and moderators via Discord DM, Twitter DM to @CodeCafeOnline, in a private chat during a live event, or by emailing [TheOriginalPixi@gmail.com](mailto:TheOriginalPixi@gmail.com?subject=CoC%20Alert%20for%20Code%20Cafe%20Online). If you choose to contact Emily via email, please use the subject line "CoC Alert for Code Cafe Online".
 
 Please be specific in your communication and identify:
 
@@ -39,7 +39,7 @@ Please be specific in your communication and identify:
 - the member(s) involved in the event
 - any surrounding details you think are relevant to the report
 
-Please know that your harassment report with _always_ remain anonymous. The harassing member will never be informed of who has contacted us regarding their actions. If you are concerned about potential retaliatory behavior, please feel free to make an anonymous report via email.
+Please know that your harassment report will _always_ remain anonymous. The harassing member will never be informed of who has contacted us regarding their actions. If you are concerned about potential retaliatory behavior, please feel free to make an anonymous report via email.
 
 We value your participation in our community and hope that by communicating these expectations, we can continue to enjoy a harassment-free environment.
 
@@ -47,14 +47,14 @@ We value your participation in our community and hope that by communicating thes
 
 ### Code Cafe Online observes and enforces the following:
 
-_We recognize that everyone makes mistakes. We are forgiving, but not lenient. Repeated violations of these rules and regulations will result in actions deemed appropriate by admins and moderators, including warning the offender and permanent explusion from community spaces._
+_We recognize that everyone makes mistakes. We are forgiving, but not lenient. Repeated violations of these rules and regulations will result in actions deemed appropriate by admins and moderators, including warning the offender and permanent expulsion from community spaces._
 
 1. **THIS IS A SAFE SPACE.**
    - We aim to be a safe space for all of our members. We consider impact before intent, and prioritize the safety of marginalized people over the comfort of the privileged. This means that, especially as a cis/straight/white person, you might be called out on problematic behavior. Do not confuse the discomfort this brings with being ‘unsafe’.
    - We expect you to get explicit, enthusiastic consent for any manner of contact, including sexual attention, and simulated physical contact in online conversations. Respect boundaries, including, but not
      limited to, the withdrawal of consent at any time.
 2. **WE ARE INCLUSIVE.**
-   - Do not engage in racist, homophobic, transphobic, ableist, sexist, ageist, or otherwise exclusionary behavior, including, but not limited to, any and all forms of shaming, erasure, gaslighting, and victim blaming.
+   - Do not engage in racist, homophobic, transphobic, ableist, sexist, ageist, or otherwise exclusionary behavior, including, but not limited to, any and all forms of shaming, erasure, gaslighting, and victim-blaming.
    - Do not make exclusionary jokes, not even ironically.
    - Do not use offensive, exclusionary, or harassing language.
 3. **WE ARE INTERSECTIONAL.**


### PR DESCRIPTION
Hi @thecodepixi! This provides fixes for a couple reversions in spelling, and also adds a `mailto` link (lemme know if that's unwanted and I'll happily remove it from the commit)